### PR TITLE
Fix infinite-loop bug.

### DIFF
--- a/Assets/Spriter2UnityDX/Editor/AnimationBuilder.cs
+++ b/Assets/Spriter2UnityDX/Editor/AnimationBuilder.cs
@@ -96,7 +96,7 @@ namespace Spriter2UnityDX.Animations {
 				var cachedEvents = oldClip.events;
 				EditorUtility.CopySerialized (clip, oldClip);
 				clip = oldClip;
-				AnimationUtility.SetAnimationEvents (clip, cachedEvents)
+				AnimationUtility.SetAnimationEvents (clip, cachedEvents);
 				ProcessingInfo.ModifiedAnims.Add (clip);
 			} else {
 				AssetDatabase.AddObjectToAsset (clip, PrefabPath); //Otherwise create a new one

--- a/Assets/Spriter2UnityDX/Editor/PrefabBuilder.cs
+++ b/Assets/Spriter2UnityDX/Editor/PrefabBuilder.cs
@@ -165,7 +165,7 @@ namespace Spriter2UnityDX.Prefabs {
 			var importer = TextureImporter.GetAtPath (path) as TextureImporter;
 			if (importer != null) { //If no TextureImporter exists, there's no texture to be found
 				if ((importer.textureType != TextureImporterType.Sprite || importer.spritePivot.x != file.pivot_x 
-				     || importer.spritePivot.y != file.pivot_y) && !InvalidImporters.Contains (importer)) {
+				     || importer.spritePivot.y != 1-file.pivot_y) && !InvalidImporters.Contains (importer)) {
 					if (success) success = false; //If the texture type isn't Sprite, or the pivot isn't set properly, 
 					var settings = new TextureImporterSettings (); //set the texture type and pivot
 					importer.ReadTextureSettings (settings);	//and make success false so the process can abort


### PR DESCRIPTION
Tiny change where the prefab builder was incorrectly checking the pivot of imported sprites and creating an infinite loop. There was also a missing semicolon in the latest commit.