### PR TITLE
Unity 2019 Support

### DIFF
--- a/Assets/Spriter2UnityDX/Editor/AnimationBuilder.cs
+++ b/Assets/Spriter2UnityDX/Editor/AnimationBuilder.cs
@@ -46,7 +46,7 @@ namespace Spriter2UnityDX.Animations {
 		}
 
 		public Object[] GetOrigClips () {
-			switch (S2USettings.ImportStyle) {
+			switch (S2USettings.GetOrCreateSettings().ImportOption) {
 			case AnimationImportOption.NestedInPrefab :
 				return AssetDatabase.LoadAllAssetRepresentationsAtPath(PrefabPath);
 			case AnimationImportOption.SeparateFolder :
@@ -112,7 +112,7 @@ namespace Spriter2UnityDX.Animations {
 				AnimationUtility.SetAnimationEvents (clip, cachedEvents);
 				ProcessingInfo.ModifiedAnims.Add (clip);
 			} else {
-				switch (S2USettings.ImportStyle) {
+				switch (S2USettings.GetOrCreateSettings().ImportOption) {
 				case AnimationImportOption.NestedInPrefab : 
 					AssetDatabase.AddObjectToAsset (clip, PrefabPath); //Otherwise create a new one
 					break;

--- a/Assets/Spriter2UnityDX/Editor/CustomEditors.cs
+++ b/Assets/Spriter2UnityDX/Editor/CustomEditors.cs
@@ -23,18 +23,21 @@ namespace Spriter2UnityDX.Editors {
 
 		public override void OnInspectorGUI ()
 		{
-			var changed = false;
+			EditorGUI.BeginChangeCheck();
 			var color = EditorGUILayout.ColorField ("Color", renderer.Color);
-			if (color != renderer.Color) {renderer.Color = color; changed = true;}
+			if (color != renderer.Color) {renderer.Color = color;}
 			var material = (Material)EditorGUILayout.ObjectField ("Material", renderer.Material, typeof(Material), false);
-			if (material != renderer.Material) {renderer.Material = material; changed = true;}
+			if (material != renderer.Material) {renderer.Material = material;}
 			var sortIndex = EditorGUILayout.Popup ("Sorting Layer", GetIndex (renderer.SortingLayerName), layerNames, GUILayout.ExpandWidth (true));
-			if (layerNames [sortIndex] != renderer.SortingLayerName) {renderer.SortingLayerName = layerNames[sortIndex]; changed = true;}
+			if (layerNames [sortIndex] != renderer.SortingLayerName) {renderer.SortingLayerName = layerNames[sortIndex];}
 			var sortingOrder = EditorGUILayout.IntField ("Order In Layer", renderer.SortingOrder);
-			if (sortingOrder != renderer.SortingOrder) {renderer.SortingOrder = sortingOrder; changed = true;}
+			if (sortingOrder != renderer.SortingOrder) {renderer.SortingOrder = sortingOrder;}
 			var applyZ = EditorGUILayout.Toggle ("Apply Spriter Z Order", renderer.ApplySpriterZOrder);
-			if (applyZ != renderer.ApplySpriterZOrder) {renderer.ApplySpriterZOrder = applyZ; changed = true;}
-			if (changed) EditorUtility.SetDirty(renderer);
+			if (applyZ != renderer.ApplySpriterZOrder) {renderer.ApplySpriterZOrder = applyZ;}
+			if (EditorGUI.EndChangeCheck())
+			{
+				EditorUtility.SetDirty(renderer);
+			}
 		}
 
 		private int GetIndex (string layerName) {

--- a/Assets/Spriter2UnityDX/Editor/PrefabBuilder.cs
+++ b/Assets/Spriter2UnityDX/Editor/PrefabBuilder.cs
@@ -39,7 +39,7 @@ namespace Spriter2UnityDX.Prefabs {
 				GameObject instance;
 				if (prefab == null) { //Creates an empty prefab if one doesn't already exists
 					instance = new GameObject (entity.name);
-					prefab = PrefabUtility.CreatePrefab (prefabPath, instance, ReplacePrefabOptions.ConnectToPrefab);
+					prefab = PrefabUtility.SaveAsPrefabAssetAndConnect (instance, prefabPath, InteractionMode.AutomatedAction);
 					ProcessingInfo.NewPrefabs.Add (prefab);
 				}
 				else {
@@ -156,7 +156,7 @@ namespace Spriter2UnityDX.Prefabs {
 				}
 			}
 			if (instance.GetComponent<EntityRenderer> () == null) instance.AddComponent<EntityRenderer> (); //Adds an EntityRenderer if one is not already present
-			PrefabUtility.ReplacePrefab (instance, prefab, ReplacePrefabOptions.ConnectToPrefab);
+			PrefabUtility.SaveAsPrefabAssetAndConnect (instance, prefabPath, InteractionMode.AutomatedAction);
 			DestroyImmediate (instance); //Apply the instance's changes to the prefab, then destroy the instance.
 		}
 
@@ -169,7 +169,7 @@ namespace Spriter2UnityDX.Prefabs {
 					if (success) success = false; //If the texture type isn't Sprite, or the pivot isn't set properly, 
 					var settings = new TextureImporterSettings (); //set the texture type and pivot
 					importer.ReadTextureSettings (settings);	//and make success false so the process can abort
-					settings.ApplyTextureType (TextureImporterType.Sprite, true); //after all the textures have been processed
+					settings.ApplyTextureType (TextureImporterType.Sprite); //after all the textures have been processed
 					settings.spriteAlignment = (int)SpriteAlignment.Custom;
 					settings.spritePivot = new Vector2 (file.pivot_x, file.pivot_y);
                     if(ScmlImportOptions.options != null)

--- a/Assets/Spriter2UnityDX/Editor/Settings.asset
+++ b/Assets/Spriter2UnityDX/Editor/Settings.asset
@@ -3,12 +3,13 @@
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9f361e2f9624e406e9f836e8793ee5b8, type: 3}
   m_Name: Settings
   m_EditorClassIdentifier: 
-  AnimationImportStyle: 1
+  importOption: 0


### PR DESCRIPTION
### Summary

Unity 2018.3 introduced new prefab workflows API resulting in obsolete method usage warnings for the project. Also selecting prefab generated by Spriter2UnityDX in project view shows infinite microloading.

**IMPORTANT: New prefab workflow API requires Unity 2018.3. Currently changes are not guarded by defines to support older versions of Unity, so minimum required version for the project becomes Unity 2018.3.**

Fixed all the project warnings produced by Unity 2019.1.9f1:
* `Assets\Spriter2UnityDX\Editor\PrefabBuilder.cs(42,65): warning CS0618: 'ReplacePrefabOptions' is obsolete: 'This has turned into the more explicit APIs, SavePrefabAsset, SaveAsPrefabAsset, SaveAsPrefabAssetAndConnect'`
* `Assets\Spriter2UnityDX\Editor\PrefabBuilder.cs(42,15): warning CS0618: 'PrefabUtility.CreatePrefab(string, GameObject, ReplacePrefabOptions)' is obsolete: 'Use SaveAsPrefabAsset or SaveAsPrefabAssetAndConnect instead.'`
* `Assets\Spriter2UnityDX\Editor\PrefabBuilder.cs(159,51): warning CS0618: 'ReplacePrefabOptions' is obsolete: 'This has turned into the more explicit APIs, SavePrefabAsset, SaveAsPrefabAsset, SaveAsPrefabAssetAndConnect'`
* `Assets\Spriter2UnityDX\Editor\PrefabBuilder.cs(159,4): warning CS0618: 'PrefabUtility.ReplacePrefab(GameObject, Object, ReplacePrefabOptions)' is obsolete: 'Use SaveAsPrefabAsset or SaveAsPrefabAssetAndConnect with a path instead.'`
* `Assets\Spriter2UnityDX\Editor\PrefabBuilder.cs(172,6): warning CS0618: 'TextureImporterSettings.ApplyTextureType(TextureImporterType, bool)' is obsolete: 'ApplyTextureType(TextureImporterType, bool) is deprecated, use ApplyTextureType(TextureImporterType)'`
* `There are menu items registered under Edit/Project Settings: Spriter2UnityDX
Consider using [SettingsProvider] attribute to register in the Unified Settings Window.`

Changes in project settings are not comitted but can be if needed.

### How to test
Tested importing scml file using Unity 2018.3.1f1 and Unity 2019.1.9f1. Open the project using Unity 2018.3 or later. Observe not compilation warnings. Import scml file and observe prefab is correctly generated. Open project settings: **Edit -> Project Settings...** and observe animation import option present in Spriter2UnityDX section and properly changed in scriptable object on modifications.

Closes #20 
